### PR TITLE
feat(customer): profile & address database models (#23)

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\CustomerProfile;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -168,9 +171,9 @@ class CustomerController extends Controller
         $orders = $this->getMockOrders();
 
         $activeStatuses = ['pending', 'assigned', 'on_the_way', 'arrived', 'processing'];
-        $activeOrders = array_filter($orders, fn($o) => in_array($o['status'], $activeStatuses));
-        $completedOrders = array_filter($orders, fn($o) => $o['status'] === 'done');
-        $pendingPayments = array_filter($orders, fn($o) => $o['payment_status'] === 'unpaid');
+        $activeOrders = array_filter($orders, fn ($o) => in_array($o['status'], $activeStatuses));
+        $completedOrders = array_filter($orders, fn ($o) => $o['status'] === 'done');
+        $pendingPayments = array_filter($orders, fn ($o) => $o['payment_status'] === 'unpaid');
 
         $stats = [
             'total_orders' => count($orders),
@@ -207,7 +210,7 @@ class CustomerController extends Controller
         $orders = $this->getMockOrders();
         $found = collect($orders)->firstWhere('id', (int) $order);
 
-        if (!$found) {
+        if (! $found) {
             abort(404);
         }
 
@@ -255,18 +258,10 @@ class CustomerController extends Controller
      */
     public function profile(): Response
     {
-        // Mock profile data
-        $profile = [
-            'id' => 1,
-            'user_id' => 1,
+        $user = auth()->user();
+        $profile = $user->customerProfile ?? new CustomerProfile([
             'customer_type' => 'household',
-            'company_name' => null,
-            'npwp' => null,
-            'pic_name' => null,
-            'business_type' => null,
-            'created_at' => '2026-01-10 08:00:00',
-            'updated_at' => '2026-01-10 08:00:00',
-        ];
+        ]);
 
         return Inertia::render('Customer/Profile', [
             'profile' => $profile,
@@ -274,10 +269,38 @@ class CustomerController extends Controller
     }
 
     /**
-     * Update profile (stub)
+     * Update profile
      */
-    public function updateProfile(Request $request)
+    public function updateProfile(Request $request): RedirectResponse
     {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'customer_type' => ['required', Rule::in(['household', 'institution'])],
+            'company_name' => ['nullable', 'string', 'max:255'],
+            'npwp' => ['nullable', 'string', 'max:30'],
+            'pic_name' => ['nullable', 'string', 'max:255'],
+            'business_type' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $user = auth()->user();
+
+        $user->update([
+            'name' => $validated['name'],
+            'phone' => $validated['phone'],
+        ]);
+
+        $user->customerProfile()->updateOrCreate(
+            ['user_id' => $user->id],
+            [
+                'customer_type' => $validated['customer_type'],
+                'company_name' => $validated['company_name'],
+                'npwp' => $validated['npwp'],
+                'pic_name' => $validated['pic_name'],
+                'business_type' => $validated['business_type'],
+            ],
+        );
+
         return back()->with('success', 'Profil berhasil diperbarui');
     }
 

--- a/app/Models/CustomerAddress.php
+++ b/app/Models/CustomerAddress.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CustomerAddress extends Model
+{
+    protected $fillable = [
+        'label',
+        'address',
+        'lat',
+        'lng',
+        'is_default',
+        'notes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'lat' => 'decimal:8',
+            'lng' => 'decimal:8',
+            'is_default' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Set this address as the default, unsetting others for the same user.
+     */
+    public function setAsDefault(): void
+    {
+        self::where('user_id', $this->user_id)
+            ->where('id', '!=', $this->id)
+            ->update(['is_default' => false]);
+
+        $this->update(['is_default' => true]);
+    }
+}

--- a/app/Models/CustomerProfile.php
+++ b/app/Models/CustomerProfile.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CustomerProfile extends Model
+{
+    protected $fillable = [
+        'customer_type',
+        'company_name',
+        'npwp',
+        'pic_name',
+        'business_type',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeHousehold(Builder $query): Builder
+    {
+        return $query->where('customer_type', 'household');
+    }
+
+    public function scopeInstitution(Builder $query): Builder
+    {
+        return $query->where('customer_type', 'institution');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -17,8 +19,11 @@ class User extends Authenticatable
      * User roles
      */
     public const ROLE_ADMIN = 'admin';
+
     public const ROLE_DRIVER = 'driver';
+
     public const ROLE_AUDITOR = 'auditor';
+
     public const ROLE_CUSTOMER = 'customer';
 
     public const ROLES = [
@@ -105,5 +110,20 @@ class User extends Authenticatable
     public function isCustomer(): bool
     {
         return $this->hasRole(self::ROLE_CUSTOMER);
+    }
+
+    public function customerProfile(): HasOne
+    {
+        return $this->hasOne(CustomerProfile::class);
+    }
+
+    public function customerAddresses(): HasMany
+    {
+        return $this->hasMany(CustomerAddress::class);
+    }
+
+    public function defaultAddress(): HasOne
+    {
+        return $this->hasOne(CustomerAddress::class)->where('is_default', true);
     }
 }

--- a/database/migrations/2026_03_08_000001_create_customer_profiles_table.php
+++ b/database/migrations/2026_03_08_000001_create_customer_profiles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customer_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->enum('customer_type', ['household', 'institution'])->default('household');
+            $table->string('company_name')->nullable();
+            $table->string('npwp')->nullable();
+            $table->string('pic_name')->nullable();
+            $table->string('business_type')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_profiles');
+    }
+};

--- a/database/migrations/2026_03_08_000002_create_customer_addresses_table.php
+++ b/database/migrations/2026_03_08_000002_create_customer_addresses_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customer_addresses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->text('address');
+            $table->decimal('lat', 10, 8);
+            $table->decimal('lng', 11, 8);
+            $table->boolean('is_default')->default(false);
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_addresses');
+    }
+};

--- a/resources/js/pages/Customer/Profile.tsx
+++ b/resources/js/pages/Customer/Profile.tsx
@@ -1,5 +1,5 @@
 import { Head, useForm, usePage } from '@inertiajs/react';
-import { Building2, Home, Save } from 'lucide-react';
+import { Building2, CheckCircle2, Home, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -20,10 +20,12 @@ interface Props {
 }
 
 export default function Profile({ profile }: Props) {
-    const { auth } = usePage().props;
+    const { auth, flash } = usePage<{
+        flash?: { success?: string };
+    }>().props;
     const user = auth.user!;
 
-    const { data, setData, put, processing } = useForm({
+    const { data, setData, put, processing, errors } = useForm({
         name: user.name,
         phone: user.phone ?? '',
         customer_type: profile.customer_type,
@@ -52,6 +54,14 @@ export default function Profile({ profile }: Props) {
                     Profil Saya
                 </h1>
 
+                {/* Success Flash */}
+                {flash?.success && (
+                    <div className="flex items-center gap-2 rounded-lg bg-green-50 p-3 text-sm text-green-700">
+                        <CheckCircle2 className="h-4 w-4 shrink-0" />
+                        {flash.success}
+                    </div>
+                )}
+
                 {/* Personal Info */}
                 <Card>
                     <CardHeader className="pb-3">
@@ -74,6 +84,11 @@ export default function Profile({ profile }: Props) {
                                     )
                                 }
                             />
+                            {errors.name && (
+                                <p className="text-xs text-destructive">
+                                    {errors.name}
+                                </p>
+                            )}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="email">
@@ -101,6 +116,11 @@ export default function Profile({ profile }: Props) {
                                 }
                                 placeholder="081234567890"
                             />
+                            {errors.phone && (
+                                <p className="text-xs text-destructive">
+                                    {errors.phone}
+                                </p>
+                            )}
                         </div>
                     </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary
- Add `customer_profiles` and `customer_addresses` database migrations
- Create `CustomerProfile` model with `household`/`institution` scopes
- Create `CustomerAddress` model with `setAsDefault()` method and boolean cast
- Add User model relationships: `customerProfile()`, `customerAddresses()`, `defaultAddress()`
- Replace mock profile controller with real validation and `updateOrCreate` logic
- Add validation error display and success flash message to Profile.tsx

Closes #23

## Test plan
- [ ] Run `php artisan migrate` — two new tables created without errors
- [ ] Visit `/customer/profile` — form loads with empty profile (first visit) or existing data
- [ ] Submit profile form — data persists to `customer_profiles` table
- [ ] Change customer type to Institution — conditional fields appear and save correctly
- [ ] Validation errors display inline (e.g., empty name field)
- [ ] Success flash shows green banner after save
- [ ] `CustomerAddress::setAsDefault()` correctly unsets other defaults for same user

🤖 Generated with [Claude Code](https://claude.com/claude-code)