### PR TITLE
feat(customer): saved addresses management (#24)

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\CustomerAddress;
 use App\Models\CustomerProfile;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -131,39 +132,6 @@ class CustomerController extends Controller
     }
 
     /**
-     * Mock customer addresses
-     */
-    private function getMockAddresses(): array
-    {
-        return [
-            [
-                'id' => 1,
-                'user_id' => 1,
-                'label' => 'Rumah',
-                'address' => 'Jl. Raden Intan No. 45, Tanjung Karang, Bandar Lampung',
-                'lat' => -5.4295,
-                'lng' => 105.2619,
-                'is_default' => true,
-                'notes' => 'Rumah warna biru, pagar hitam',
-                'created_at' => '2026-01-10 08:00:00',
-                'updated_at' => '2026-01-10 08:00:00',
-            ],
-            [
-                'id' => 2,
-                'user_id' => 1,
-                'label' => 'Kantor',
-                'address' => 'Jl. Diponegoro No. 12, Kedaton, Bandar Lampung',
-                'lat' => -5.3891,
-                'lng' => 105.2456,
-                'is_default' => false,
-                'notes' => 'Gedung lantai 2, masuk dari samping',
-                'created_at' => '2026-02-05 10:00:00',
-                'updated_at' => '2026-02-05 10:00:00',
-            ],
-        ];
-    }
-
-    /**
      * Customer Dashboard - /customer
      */
     public function dashboard(): Response
@@ -224,33 +192,140 @@ class CustomerController extends Controller
      */
     public function addresses(): Response
     {
+        $addresses = auth()->user()->customerAddresses()
+            ->orderByDesc('is_default')
+            ->orderBy('label')
+            ->get();
+
         return Inertia::render('Customer/Addresses', [
-            'addresses' => $this->getMockAddresses(),
+            'addresses' => $addresses,
         ]);
     }
 
     /**
-     * Store address (stub)
+     * Create address form - /customer/addresses/create
      */
-    public function storeAddress(Request $request)
+    public function createAddress(): Response|RedirectResponse
     {
-        return back()->with('success', 'Alamat berhasil ditambahkan');
+        $count = auth()->user()->customerAddresses()->count();
+
+        if ($count >= 5) {
+            return redirect()->route('customer.addresses')
+                ->with('error', 'Maksimum 5 alamat. Hapus alamat lama untuk menambahkan yang baru.');
+        }
+
+        return Inertia::render('Customer/Addresses/Form', [
+            'address' => null,
+        ]);
     }
 
     /**
-     * Update address (stub)
+     * Store address
      */
-    public function updateAddress(Request $request, string $address)
+    public function storeAddress(Request $request): RedirectResponse
     {
-        return back()->with('success', 'Alamat berhasil diperbarui');
+        $user = auth()->user();
+
+        if ($user->customerAddresses()->count() >= 5) {
+            return back()->withErrors(['limit' => 'Maksimum 5 alamat tercapai.']);
+        }
+
+        $validated = $request->validate([
+            'label' => ['required', 'string', 'max:50'],
+            'address' => ['required', 'string', 'max:500'],
+            'lat' => ['required', 'numeric', 'between:-90,90'],
+            'lng' => ['required', 'numeric', 'between:-180,180'],
+            'notes' => ['nullable', 'string', 'max:255'],
+            'is_default' => ['boolean'],
+        ]);
+
+        $address = $user->customerAddresses()->create($validated);
+
+        // Auto-set as default if first address or requested
+        if ($user->customerAddresses()->count() === 1 || ($validated['is_default'] ?? false)) {
+            $address->setAsDefault();
+        }
+
+        return redirect()->route('customer.addresses')
+            ->with('success', 'Alamat berhasil ditambahkan');
     }
 
     /**
-     * Delete address (stub)
+     * Edit address form - /customer/addresses/{address}/edit
      */
-    public function destroyAddress(string $address)
+    public function editAddress(CustomerAddress $address): Response
     {
-        return back()->with('success', 'Alamat berhasil dihapus');
+        if ($address->user_id !== auth()->id()) {
+            abort(403);
+        }
+
+        return Inertia::render('Customer/Addresses/Form', [
+            'address' => $address,
+        ]);
+    }
+
+    /**
+     * Update address
+     */
+    public function updateAddress(Request $request, CustomerAddress $address): RedirectResponse
+    {
+        if ($address->user_id !== auth()->id()) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'label' => ['required', 'string', 'max:50'],
+            'address' => ['required', 'string', 'max:500'],
+            'lat' => ['required', 'numeric', 'between:-90,90'],
+            'lng' => ['required', 'numeric', 'between:-180,180'],
+            'notes' => ['nullable', 'string', 'max:255'],
+            'is_default' => ['boolean'],
+        ]);
+
+        $address->update($validated);
+
+        if ($validated['is_default'] ?? false) {
+            $address->setAsDefault();
+        }
+
+        return redirect()->route('customer.addresses')
+            ->with('success', 'Alamat berhasil diperbarui');
+    }
+
+    /**
+     * Delete address
+     */
+    public function destroyAddress(CustomerAddress $address): RedirectResponse
+    {
+        if ($address->user_id !== auth()->id()) {
+            abort(403);
+        }
+
+        $wasDefault = $address->is_default;
+        $address->delete();
+
+        // If deleted address was default, set the first remaining as default
+        if ($wasDefault) {
+            $firstAddress = auth()->user()->customerAddresses()->first();
+            $firstAddress?->setAsDefault();
+        }
+
+        return redirect()->route('customer.addresses')
+            ->with('success', 'Alamat berhasil dihapus');
+    }
+
+    /**
+     * Set address as default
+     */
+    public function setDefaultAddress(CustomerAddress $address): RedirectResponse
+    {
+        if ($address->user_id !== auth()->id()) {
+            abort(403);
+        }
+
+        $address->setAsDefault();
+
+        return back()->with('success', 'Alamat default berhasil diubah');
     }
 
     /**

--- a/resources/js/pages/Customer/Addresses.tsx
+++ b/resources/js/pages/Customer/Addresses.tsx
@@ -1,5 +1,11 @@
-import { Head } from '@inertiajs/react';
-import { MapPin, MoreVertical, Plus, Star } from 'lucide-react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import {
+    CheckCircle2,
+    MapPin,
+    MoreVertical,
+    Plus,
+    Star,
+} from 'lucide-react';
 import { EmptyState } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -24,7 +30,20 @@ interface Props {
 const MAX_ADDRESSES = 5;
 
 export default function Addresses({ addresses }: Props) {
+    const { flash } = usePage<{
+        flash?: { success?: string };
+    }>().props;
     const canAdd = addresses.length < MAX_ADDRESSES;
+
+    const handleSetDefault = (id: number) => {
+        router.put(`/customer/addresses/${id}/default`);
+    };
+
+    const handleDelete = (id: number) => {
+        if (confirm('Yakin ingin menghapus alamat ini?')) {
+            router.delete(`/customer/addresses/${id}`);
+        }
+    };
 
     return (
         <CustomerLayout>
@@ -42,12 +61,26 @@ export default function Addresses({ addresses }: Props) {
                         </p>
                     </div>
                     {canAdd && (
-                        <Button size="sm" className="gap-1">
-                            <Plus className="h-4 w-4" />
-                            Tambah
+                        <Button
+                            asChild
+                            size="sm"
+                            className="gap-1"
+                        >
+                            <Link href="/customer/addresses/create">
+                                <Plus className="h-4 w-4" />
+                                Tambah
+                            </Link>
                         </Button>
                     )}
                 </div>
+
+                {/* Success Flash */}
+                {flash?.success && (
+                    <div className="flex items-center gap-2 rounded-lg bg-green-50 p-3 text-sm text-green-700">
+                        <CheckCircle2 className="h-4 w-4 shrink-0" />
+                        {flash.success}
+                    </div>
+                )}
 
                 {addresses.length > 0 ? (
                     <div className="space-y-3">
@@ -84,16 +117,35 @@ export default function Addresses({ addresses }: Props) {
                                             </Button>
                                         </DropdownMenuTrigger>
                                         <DropdownMenuContent align="end">
-                                            <DropdownMenuItem>
-                                                Edit
+                                            <DropdownMenuItem
+                                                asChild
+                                            >
+                                                <Link
+                                                    href={`/customer/addresses/${address.id}/edit`}
+                                                >
+                                                    Edit
+                                                </Link>
                                             </DropdownMenuItem>
                                             {!address.is_default && (
-                                                <DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    onClick={() =>
+                                                        handleSetDefault(
+                                                            address.id,
+                                                        )
+                                                    }
+                                                >
                                                     Jadikan
                                                     Default
                                                 </DropdownMenuItem>
                                             )}
-                                            <DropdownMenuItem className="text-destructive">
+                                            <DropdownMenuItem
+                                                className="text-destructive"
+                                                onClick={() =>
+                                                    handleDelete(
+                                                        address.id,
+                                                    )
+                                                }
+                                            >
                                                 Hapus
                                             </DropdownMenuItem>
                                         </DropdownMenuContent>

--- a/resources/js/pages/Customer/Addresses/Form.tsx
+++ b/resources/js/pages/Customer/Addresses/Form.tsx
@@ -1,0 +1,288 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import { ArrowLeft } from 'lucide-react';
+import { MapPicker } from '@/components/forms';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import CustomerLayout from '@/layouts/CustomerLayout';
+import { cn } from '@/lib/utils';
+import type { CustomerAddress } from '@/types/customer';
+
+interface Props {
+    address: CustomerAddress | null;
+}
+
+const LABEL_PRESETS = ['Rumah', 'Kantor', 'Kos'];
+
+export default function AddressForm({ address }: Props) {
+    const isEditing = address !== null;
+
+    const { data, setData, post, put, processing, errors } =
+        useForm({
+            label: address?.label ?? '',
+            address: address?.address ?? '',
+            lat: address?.lat ?? 0,
+            lng: address?.lng ?? 0,
+            notes: address?.notes ?? '',
+            is_default: address?.is_default ?? false,
+        });
+
+    const handleMapChange = (location: {
+        lat: number;
+        lng: number;
+        address?: string;
+    }) => {
+        setData((prev) => ({
+            ...prev,
+            lat: location.lat,
+            lng: location.lng,
+            address: location.address ?? prev.address,
+        }));
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (isEditing) {
+            put(`/customer/addresses/${address.id}`);
+        } else {
+            post('/customer/addresses');
+        }
+    };
+
+    const handleLabelPreset = (label: string) => {
+        setData('label', label);
+    };
+
+    const isCustomLabel =
+        data.label !== '' && !LABEL_PRESETS.includes(data.label);
+
+    return (
+        <CustomerLayout>
+            <Head
+                title={
+                    isEditing
+                        ? 'Edit Alamat'
+                        : 'Tambah Alamat'
+                }
+            />
+
+            <form
+                onSubmit={handleSubmit}
+                className="space-y-4 p-4"
+            >
+                {/* Back button */}
+                <Link
+                    href="/customer/addresses"
+                    className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    Kembali
+                </Link>
+
+                <h1 className="text-xl font-bold">
+                    {isEditing
+                        ? 'Edit Alamat'
+                        : 'Tambah Alamat'}
+                </h1>
+
+                {/* Label */}
+                <Card>
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-sm">
+                            Label
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <div className="flex flex-wrap gap-2">
+                            {LABEL_PRESETS.map((preset) => (
+                                <button
+                                    key={preset}
+                                    type="button"
+                                    onClick={() =>
+                                        handleLabelPreset(
+                                            preset,
+                                        )
+                                    }
+                                    className={cn(
+                                        'rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                        data.label === preset
+                                            ? 'border-primary bg-primary/10 text-primary'
+                                            : 'border-muted hover:border-muted-foreground/30',
+                                    )}
+                                >
+                                    {preset}
+                                </button>
+                            ))}
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    setData('label', '')
+                                }
+                                className={cn(
+                                    'rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                    isCustomLabel
+                                        ? 'border-primary bg-primary/10 text-primary'
+                                        : 'border-muted hover:border-muted-foreground/30',
+                                )}
+                            >
+                                Lainnya
+                            </button>
+                        </div>
+                        {(isCustomLabel ||
+                            (!LABEL_PRESETS.includes(
+                                data.label,
+                            ) &&
+                                data.label === '')) && (
+                            <Input
+                                placeholder="Masukkan label..."
+                                value={
+                                    isCustomLabel
+                                        ? data.label
+                                        : ''
+                                }
+                                onChange={(e) =>
+                                    setData(
+                                        'label',
+                                        e.target.value,
+                                    )
+                                }
+                                autoFocus
+                            />
+                        )}
+                        {errors.label && (
+                            <p className="text-xs text-destructive">
+                                {errors.label}
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
+
+                {/* Address + Map */}
+                <Card>
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-sm">
+                            Lokasi
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="address">
+                                Alamat Lengkap
+                            </Label>
+                            <Textarea
+                                id="address"
+                                value={data.address}
+                                onChange={(e) =>
+                                    setData(
+                                        'address',
+                                        e.target.value,
+                                    )
+                                }
+                                placeholder="Jl. Contoh No. 123, Kelurahan, Kecamatan"
+                                rows={2}
+                            />
+                            {errors.address && (
+                                <p className="text-xs text-destructive">
+                                    {errors.address}
+                                </p>
+                            )}
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label>
+                                Pilih Lokasi di Peta
+                            </Label>
+                            <MapPicker
+                                value={
+                                    data.lat && data.lng
+                                        ? {
+                                              lat: data.lat,
+                                              lng: data.lng,
+                                              address:
+                                                  data.address,
+                                          }
+                                        : undefined
+                                }
+                                onChange={handleMapChange}
+                                className="h-[250px]"
+                            />
+                            {(errors.lat || errors.lng) && (
+                                <p className="text-xs text-destructive">
+                                    Pilih lokasi di peta
+                                </p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+
+                {/* Notes */}
+                <Card>
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-sm">
+                            Catatan (Opsional)
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Textarea
+                            value={data.notes}
+                            onChange={(e) =>
+                                setData(
+                                    'notes',
+                                    e.target.value,
+                                )
+                            }
+                            placeholder="Patokan, warna rumah, akses jalan..."
+                            rows={2}
+                        />
+                        {errors.notes && (
+                            <p className="text-xs text-destructive">
+                                {errors.notes}
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
+
+                {/* Default checkbox */}
+                <div className="flex items-center gap-2 rounded-lg border p-4">
+                    <Checkbox
+                        id="is_default"
+                        checked={data.is_default}
+                        onCheckedChange={(checked) =>
+                            setData(
+                                'is_default',
+                                checked === true,
+                            )
+                        }
+                    />
+                    <Label
+                        htmlFor="is_default"
+                        className="text-sm"
+                    >
+                        Jadikan alamat default
+                    </Label>
+                </div>
+
+                {/* Submit */}
+                <Button
+                    type="submit"
+                    className="w-full"
+                    disabled={processing}
+                >
+                    {processing
+                        ? 'Menyimpan...'
+                        : isEditing
+                          ? 'Simpan Perubahan'
+                          : 'Tambah Alamat'}
+                </Button>
+            </form>
+        </CustomerLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,9 +67,12 @@ Route::prefix('customer')->middleware(['auth', 'verified', 'role:customer'])->na
     Route::post('/orders/{order}/reorder', [CustomerController::class, 'reorder'])->name('orders.reorder');
     Route::post('/orders/{order}/payment-proof', [CustomerController::class, 'uploadPaymentProof'])->name('orders.payment-proof');
     Route::get('/addresses', [CustomerController::class, 'addresses'])->name('addresses');
+    Route::get('/addresses/create', [CustomerController::class, 'createAddress'])->name('addresses.create');
     Route::post('/addresses', [CustomerController::class, 'storeAddress'])->name('addresses.store');
+    Route::get('/addresses/{address}/edit', [CustomerController::class, 'editAddress'])->name('addresses.edit');
     Route::put('/addresses/{address}', [CustomerController::class, 'updateAddress'])->name('addresses.update');
     Route::delete('/addresses/{address}', [CustomerController::class, 'destroyAddress'])->name('addresses.destroy');
+    Route::put('/addresses/{address}/default', [CustomerController::class, 'setDefaultAddress'])->name('addresses.default');
     Route::get('/profile', [CustomerController::class, 'profile'])->name('profile');
     Route::put('/profile', [CustomerController::class, 'updateProfile'])->name('profile.update');
 });


### PR DESCRIPTION
## Summary
- Full CRUD for customer saved addresses with real database operations
- Full-page address form with MapPicker (Leaflet), preset label chips (Rumah/Kantor/Kos + custom), and validation
- Server-side: max 5 addresses limit, ownership checks, auto-default on first address and on default deletion
- Wired up list page with Inertia router actions (set default, delete with confirm)
- Removed mock address data — now fully database-backed

Closes #24

## Test plan
- [ ] Navigate to `/customer/addresses` — shows empty state if no addresses
- [ ] Click "Tambah" → navigates to `/customer/addresses/create`
- [ ] Select preset label (Rumah/Kantor/Kos) or enter custom label
- [ ] Search/click/geolocate on MapPicker to set address and coordinates
- [ ] Submit form — address saved and redirected to list with success flash
- [ ] Edit address via dropdown menu → form pre-filled with existing data
- [ ] Set address as default via dropdown → badge updates
- [ ] Delete address with confirmation dialog
- [ ] Cannot add more than 5 addresses (server rejects + redirect)
- [ ] First address auto-set as default
- [ ] Deleting default address reassigns default to first remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)